### PR TITLE
Sexualized language should be an error level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 02-04-2019
+
+- Sexualized language is now an error-level rule (was warning)
+
 ## 25-03-2019
 
--   We have a changelong :)
+-   We have a changelog :)
 -   Added Java terms to spelling exceptions
 -   Added more check to WIP future tense check
 

--- a/Joblint/Sexualised.yml
+++ b/Joblint/Sexualised.yml
@@ -3,7 +3,7 @@ extends: existence
 message: "Avoid using '%s'"
 description: "Terms like '%s' are often used if the person writing a post doesn't know what they are talking about."
 ignorecase: true
-level: warning
+level: error
 tokens:
   - gay for
   - sexy


### PR DESCRIPTION
At the very least, "gay for" should be in an error-level rule, if the rest are ok as warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testthedocs/vale-styles/24)
<!-- Reviewable:end -->
