### PR TITLE
Add links to GitLab Vale yaml files

### DIFF
--- a/GitLab/README.md
+++ b/GitLab/README.md
@@ -1,0 +1,6 @@
+GitLab is in the process of implementing Vale. We have documented the process in
+our [GitLab Documentation guidelines](https://docs.gitlab.com/ee/development/documentation/#vale).
+
+You can find the rules that we've created in our [GitLab repository](https://gitlab.com/gitlab-org/gitlab/-/tree/master/doc/.vale/gitlab).
+
+The repository includes a [LICENSE](https://gitlab.com/gitlab-org/gitlab/-/blob/master/LICENSE) file.

--- a/GitLab/README.md
+++ b/GitLab/README.md
@@ -2,5 +2,3 @@ GitLab is in the process of implementing Vale. We have documented the process in
 our [GitLab Documentation guidelines](https://docs.gitlab.com/ee/development/documentation/#vale).
 
 You can find the rules that we've created in our [GitLab repository](https://gitlab.com/gitlab-org/gitlab/-/tree/master/doc/.vale/gitlab).
-
-The repository includes a [LICENSE](https://gitlab.com/gitlab-org/gitlab/-/blob/master/LICENSE) file.


### PR DESCRIPTION
# Description

Include links to the GitLab Vale implementation

## Type of change

This is info only, to provide examples for Vale users who are creating their own implementations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testthedocs/vale-styles/33)
<!-- Reviewable:end -->
